### PR TITLE
Fix #4: add action on `logs:DeleteLogGroup` for `arn:aws:logs:${region}`

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -110,7 +110,11 @@ const buildPolicy = (serviceName, stage, region) => {
         Resource: ['*']
       },
       {
-        Action: ['logs:CreateLogGroup', 'logs:CreateLogStream'],
+        Action: [
+          'logs:CreateLogGroup',
+          'logs:CreateLogStream',
+          'logs:DeleteLogGroup'
+        ],
         Resource: [`arn:aws:logs:${region}:*:*`],
         Effect: 'Allow'
       },


### PR DESCRIPTION
Fixes #4 by adding the `logs:DeleteLogGroup` permission for `arn:aws:logs:${region}`.