### PR TITLE
Added CloudFormation:ValidateTemplate permission

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -11,7 +11,8 @@ const buildPolicy = (serviceName, stage, region) => {
         Action: [
           'cloudformation:List*',
           'cloudformation:Get*',
-          'cloudformation:PreviewStackUpdate'
+          'cloudformation:PreviewStackUpdate',
+          'cloudformation:ValidateTemplate'
         ],
         Resource: ['*']
       },


### PR DESCRIPTION
Without this permission you will get an error:

The CloudFormation template is invalid: User: arn:aws: is not authorized to perform: cloudformation:ValidateTemplate