### PR TITLE
Rrstricting iam role access

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -94,7 +94,13 @@ const buildPolicy = (serviceName, stage, region) => {
       },
       {
         Effect: 'Allow',
-        Action: 'iam:*',
+        Action: [
+          'iam:GetRole',
+          'iam:CreateRole',
+          'iam:PutRolePolicy',
+          'iam:DeleteRolePolicy',
+          'iam:DeleteRole'
+      ],
         Resource: [
           `arn:aws:iam::*:role/${serviceName}-${stage}-${region}-lambdaRole`
         ]


### PR DESCRIPTION
Restricting action iam:* to specific roles required to add/delete lambda.