### PR TITLE
Allow GetBucketLocation permission

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -37,6 +37,7 @@ const buildPolicy = (serviceName, stage, region) => {
       {
         Effect: 'Allow',
         Action: [
+          "s3:GetBucketLocation",
           "s3:CreateBucket",
           "s3:DeleteBucket",
           "s3:ListBucket",


### PR DESCRIPTION
GetBucketLocation permission is required if user explicitly specifies deployment bucket in serverless.yml